### PR TITLE
Updating the library from .NET Standard 2.0 to .NET 7.0.

### DIFF
--- a/src/Unidevel.OpenWeather/Unidevel.OpenWeather.csproj
+++ b/src/Unidevel.OpenWeather/Unidevel.OpenWeather.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Version>0.9.5</Version>
     <Authors>Grzegorz Strzałkowski</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/test/Unidevel.OpenWeather.Tests/Unidevel.OpenWeather.Tests.csproj
+++ b/test/Unidevel.OpenWeather.Tests/Unidevel.OpenWeather.Tests.csproj
@@ -1,16 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
1. I chose to remove the HttpClient argument from the constructor and create it internally within the class to avoid any potential issues related to dependency injection.
2. I got rid of unnecessary try-catch blocks around HttpClient.GetStringAsync operations. Now, exceptions are thrown directly, making the code clearer and improving exception tracing accuracy.
3. Similarly, I eliminated redundant try-catch blocks to maintain transparency in the code and enable more precise exception handling.
4. I followed the guideline and removed HttpClient from the constructor's argument list. Instead, I internally create it within the class. Additionally, I implemented IDisposable to ensure proper resource disposal, such as HttpClient, when the object is no longer needed.